### PR TITLE
Use default layout for all page instead of using duplicate HTML

### DIFF
--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -5,14 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page.title }}</title>
     <link href="src/landing-page.css" rel="stylesheet">
+{% if page.url != "/." %}
     <script async src="src/app.js"></script>
+{% endif %}
     <link rel="alternate" type="application/atom+xml" href="posts.atom" title="Recent blog posts" />
 </head>
 
-<body>
+<body{{ page.url == "/." ? ' id="home"' : '' }}>
     <nav>
         <ul>
-            <li><a href="./"><strong>clue</strong>·engineering</a></li>
+            <li{{ page.url == "/." ? ' class="active"' : '' }}><a href="./"><strong>clue</strong>·engineering</a></li>
             <li{{ page.url == "/blog.html" ? ' class="active"' : '' }}><a href="blog">Blog</a></li>
             <li{{ page.url == "/talks.html" ? ' class="active"' : '' }}><a href="talks">Talks</a></li>
             <li{{ page.url == "/support.html" ? ' class="active"' : '' }}><a href="support">Support</a></li>

--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -1,28 +1,38 @@
+{% set base = page.url matches "#/.*/#" ? "../" : "" %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page.title }}</title>
-    <link href="src/landing-page.css" rel="stylesheet">
-{% if page.url != "/." %}
-    <script async src="src/app.js"></script>
+    <link href="{{base}}src/landing-page.css" rel="stylesheet">
+{# always include javascript except for index and blog posts #}
+{% if page.url != "/." and not (page.url matches "#/.*/#") %}
+    <script async src="{{base}}src/app.js"></script>
 {% endif %}
-    <link rel="alternate" type="application/atom+xml" href="posts.atom" title="Recent blog posts" />
+{# always include feed exept for blog posts? #}
+{% if not (page.url matches "#/.*/#") %}
+    <link rel="alternate" type="application/atom+xml" href="{{base}}posts.atom" title="Recent blog posts" />
+{% endif %}
+{% block head '' %}
 </head>
 
 <body{{ page.url == "/." ? ' id="home"' : '' }}>
     <nav>
         <ul>
-            <li{{ page.url == "/." ? ' class="active"' : '' }}><a href="./"><strong>clue</strong>·engineering</a></li>
-            <li{{ page.url == "/blog.html" ? ' class="active"' : '' }}><a href="blog">Blog</a></li>
-            <li{{ page.url == "/talks.html" ? ' class="active"' : '' }}><a href="talks">Talks</a></li>
-            <li{{ page.url == "/support.html" ? ' class="active"' : '' }}><a href="support">Support</a></li>
-            <li{{ page.url == "/contact.html" ? ' class="active"' : '' }}><a href="contact">Contact</a></li>
+            <li{{ page.url == "/." ? ' class="active"' : '' }}><a href="{{ base ?: "./" }}"><strong>clue</strong>·engineering</a></li>
+            <li{{ page.url == "/blog.html" or page.url matches "#/.*/#" ? ' class="active"' : '' }}><a href="{{ base }}blog">Blog</a></li>
+            <li{{ page.url == "/talks.html" ? ' class="active"' : '' }}><a href="{{ base }}talks">Talks</a></li>
+            <li{{ page.url == "/support.html" ? ' class="active"' : '' }}><a href="{{ base }}support">Support</a></li>
+            <li{{ page.url == "/contact.html" ? ' class="active"' : '' }}><a href="{{ base }}contact">Contact</a></li>
         </ul>
     </nav>
 
+{% if page.blocks.postcontent %}
+{% block postcontent '' %}
+{% else %}
 {% block content '' %}
+{% endif %}
 
     <script async type="text/javascript" src="https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com/eb0f44ef8dbe480ab49d3a956f88be6034cf2d42e0114c31a532dc47ad6a9da7.js"></script>
 </body>

--- a/www/_layouts/post.twig
+++ b/www/_layouts/post.twig
@@ -37,17 +37,16 @@
                     </address>
                     on <time datetime="{{ page.date | date("Y-m-d") }}">{{ page.date | date("Y-m-d") }}</time>
 {% if page.tags %}
-<div>
-  tagged
+                    <div>
+                        tagged
 {%     for tag in page.tags %}
-  <a href="../blog#{{ tag }}" title="Show all blog posts tagged #{{ tag }}" rel="tag">#{{ tag }}</a>
+                        <a href="../blog#{{ tag }}" title="Show all blog posts tagged #{{ tag }}" rel="tag">#{{ tag }}</a>
 {%     endfor %}
-</div>
+                    </div>
 {% endif %}
                 </div>
 
 {% block content %}{% endblock %}
-
             </article>
         </div>
     </section>

--- a/www/_layouts/post.twig
+++ b/www/_layouts/post.twig
@@ -1,13 +1,9 @@
-{% set description = page.blocks.content|raw|striptags|replace({"\n":' ', "\r":' '})|trim|split(' ')|slice(0,50)|join(' ')|raw %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ page.title }}</title>
-    <meta name="description" content="{{ description }}…">
-    <link href="../src/landing-page.css" rel="stylesheet">
+{% extends "default" %}
 
+{% block head %}
+{% set description = page.blocks.content|raw|striptags|replace({"\n":' ', "\r":' '})|trim|split(' ')|slice(0,50)|join(' ')|raw %}
+
+    <meta name="description" content="{{ description }}…">
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{ page.title }}">
     <meta property="og:description" content="{{ description }}…">
@@ -22,19 +18,9 @@
     <meta property="article:published_time" content="{{ page.date | date("Y-m-d") }}">
     <meta name="twitter:site" content="@another_clue">
     <meta name="twitter:creator" content="@another_clue">
-</head>
+{% endblock %}
 
-<body>
-    <nav>
-        <ul>
-            <li><a href="../"><strong>clue</strong>·engineering</a></li>
-            <li class="active"><a href="../blog">Blog</a></li>
-            <li><a href="../talks">Talks</a></li>
-            <li><a href="../support">Support</a></li>
-            <li><a href="../contact">Contact</a></li>
-        </ul>
-    </nav>
-
+{% block postcontent %}
     <section id="post">
         <div class="container">
             <article>
@@ -89,7 +75,4 @@
             </p>
         </div>
     </section>
-
-    <script async type="text/javascript" src="https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com/eb0f44ef8dbe480ab49d3a956f88be6034cf2d42e0114c31a532dc47ad6a9da7.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/www/contact.html
+++ b/www/contact.html
@@ -2,7 +2,6 @@
 title: Contact clue·engineering
 layout: default
 ---
-
 <section class="contact">
     <div class="container">
         <h1>

--- a/www/index.html.twig
+++ b/www/index.html.twig
@@ -93,7 +93,7 @@ use:
             </p>
         </div>
     </section>
-    
+
     <section id="projects">
         <div class="container">
             <h3>
@@ -129,7 +129,7 @@ use:
             </p>
         </div>
     </section>
-    
+
     <section id="contact">
         <div class="container">
             <h3>

--- a/www/index.html.twig
+++ b/www/index.html.twig
@@ -1,29 +1,10 @@
 ---
+title: clue·engineering by Christian Lück
+layout: default
 use:
   - posts
   - posts_tags
 ---
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>clue·engineering by Christian Lück</title>
-    <link href="src/landing-page.css" rel="stylesheet">
-    <link rel="alternate" type="application/atom+xml" href="posts.atom" title="Recent blog posts" />
-</head>
-
-<body id="home">
-    <nav>
-        <ul>
-            <li class="active"><a href="./"><strong>clue</strong>·engineering</a></li>
-            <li><a href="blog">Blog</a></li>
-            <li><a href="talks">Talks</a></li>
-            <li><a href="support">Support</a></li>
-            <li><a href="contact">Contact</a></li>
-        </ul>
-    </nav>
-
     <section id="main">
         <div>
             <div>
@@ -161,7 +142,3 @@ use:
             </p>
         </div>
     </section>
-
-    <script async type="text/javascript" src="https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com/eb0f44ef8dbe480ab49d3a956f88be6034cf2d42e0114c31a532dc47ad6a9da7.js"></script>
-</body>
-</html>


### PR DESCRIPTION
This changeset make sure we use the default layout for all page instead of using duplicate HTML. This should only have a non-significant effect on the resulting HTML output - which is why this builds on top of #68.