### PR TITLE
Remove border-left of first pricing package on support page

### DIFF
--- a/www/src/landing-page.css
+++ b/www/src/landing-page.css
@@ -709,6 +709,9 @@ ul.pricing > li {
     padding-left: 10px;
     white-space: normal; 
 }
+ul.pricing > li:first-child {
+    border-left: 0;
+}
 ul.pricing h3 {
     margin: 0;
     font-weight: bold;


### PR DESCRIPTION
**Before**
![Border-left_before](https://user-images.githubusercontent.com/62540672/95861211-699fc800-0d61-11eb-94ca-61bc6724a560.png)

**After**
![Border-left_after](https://user-images.githubusercontent.com/62540672/95861216-6ad0f500-0d61-11eb-988c-adf8a69f8f73.png)

Complement #66 