### PR TITLE
Improve navigation, highlight "Get Support" link (CTA)

### DIFF
--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -21,7 +21,6 @@
             <li{{ page.url == "/blog.html" or page.url matches "#/.*/#" ? ' class="active"' : '' }}><a href="{{ base }}blog">Blog</a></li>
             <li{{ page.url == "/talks.html" ? ' class="active"' : '' }}><a href="{{ base }}talks">Talks</a></li>
             <li{{ page.url == "/support.html" ? ' class="active"' : '' }}><a href="{{ base }}support">Support</a></li>
-            <li{{ page.url == "/contact.html" ? ' class="active"' : '' }}><a href="{{ base }}contact">Contact</a></li>
         </ul>
     </nav>
 

--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -20,7 +20,7 @@
             <li{{ page.url == "/." ? ' class="active"' : '' }}><a href="{{ base ?: "./" }}"><strong>clue</strong>·engineering</a></li>
             <li{{ page.url == "/blog.html" or page.url matches "#/.*/#" ? ' class="active"' : '' }}><a href="{{ base }}blog">Blog</a></li>
             <li{{ page.url == "/talks.html" ? ' class="active"' : '' }}><a href="{{ base }}talks">Talks</a></li>
-            <li{{ page.url == "/support.html" ? ' class="active"' : '' }}><a href="{{ base }}support">Support</a></li>
+            <li{{ page.url == "/support.html" ? ' class="active"' : '' }}><a href="{{ base }}support">Get Support</a></li>
         </ul>
     </nav>
 
@@ -40,7 +40,7 @@
                 <li><a href="{{ base }}talks">Talks</a></li>
             </ul>
             <ul>
-                <li><a href="{{ base }}support"><strong>Support</strong></a></li>
+                <li><a href="{{ base }}support"><strong>Get Support</strong></a></li>
                 <li><a href="{{ base }}support#consulting">Consulting &amp; Coaching</a></li>
                 <li><a href="{{ base }}support#sponsor">Sponsoring</a></li>
                 <li><a href="{{ base }}support#open-source">Open-Source</a></li>

--- a/www/src/landing-page.css
+++ b/www/src/landing-page.css
@@ -71,11 +71,8 @@ nav ul {
 nav li {
     display: inline-block;
     margin: 0;
-    padding: .25em 0 .5em 0;
+    padding: .25em 0 .5em .5em;
     border-top: .25em solid transparent;
-}
-nav li.active {
-    border-top-color: #408BC2;
 }
 nav li a {
     text-decoration: none;
@@ -96,6 +93,19 @@ nav li:first-child a {
     margin-top: .5em;
     padding-top: 0;
     display: inline-block;
+}
+nav li:last-child a {
+    margin-right: 2px;
+    padding: .4em 1em;
+    background-color: #408bc2;
+    color: #f8f8f8;
+    text-shadow: 1px 1px 0px #555;
+    transition: all .1s ease;
+}
+nav li:last-child a:hover {
+    background-color: #84bde6;
+    color: #fff;
+    text-shadow: 0px 0px 2px #555;
 }
 
 /* default section layout */


### PR DESCRIPTION
Old:
![Screenshot_2020-10-16 Get support and support open-source](https://user-images.githubusercontent.com/776829/96292497-a0880f00-0fe9-11eb-8c8a-346c6020b7c8.png)

New:
![Screenshot_2020-10-16 ⁣Get support and support open-source](https://user-images.githubusercontent.com/776829/96292500-a120a580-0fe9-11eb-8cf5-5c8bb6a38abf.png)

Builds on top of #74 