### PR TITLE
Unify building links to blog posts and remove unneeded legacy IDs

### DIFF
--- a/www/_posts/2018-12-19 introducing-reactphp-ssh-proxy.md
+++ b/www/_posts/2018-12-19 introducing-reactphp-ssh-proxy.md
@@ -1,6 +1,5 @@
 ---
 title: Introducing SSH proxy connector for ReactPHP
-legacy_id: https://www.lueck.tv/2018/introducing-reactphp-ssh-proxy
 tags:
   - introducing-reactphp
   - reactphp

--- a/www/_posts/2019-01-01 2018-in-review.md
+++ b/www/_posts/2019-01-01 2018-in-review.md
@@ -1,7 +1,6 @@
 ---
 title: 2018 – A Year In Review
 social_image: https://user-images.githubusercontent.com/776829/50575896-df45d880-0e06-11e9-9813-cd1f3565066c.jpeg
-legacy_id: https://www.lueck.tv/2019/2018-in-review
 tags:
   - meta
   - year-in-review

--- a/www/_posts/2019-01-07 introducing-tls-1-3-for-reactphp.md
+++ b/www/_posts/2019-01-07 introducing-tls-1-3-for-reactphp.md
@@ -1,6 +1,5 @@
 ---
 title: Introducing TLS 1.3 for ReactPHP
-legacy_id: 2019/introducing-tls-1-3-for-reactphp
 tags:
   - introducing-reactphp
   - reactphp

--- a/www/_posts/2019-01-14 introducing-reactphp-child-process.md
+++ b/www/_posts/2019-01-14 introducing-reactphp-child-process.md
@@ -1,6 +1,5 @@
 ---
 title: Introducing event-driven child process for ReactPHP
-legacy_id: 2019/introducing-reactphp-child-process
 tags:
   - introducing-reactphp
   - reactphp

--- a/www/_posts/2019-03-11 introducing-reactphp-redis.md
+++ b/www/_posts/2019-03-11 introducing-reactphp-redis.md
@@ -1,6 +1,5 @@
 ---
 title: Introducing async Redis database client for ReactPHP
-legacy_id: https://www.lueck.tv/2019/introducing-reactphp-redis
 tags:
   - introducing-reactphp
   - reactphp

--- a/www/_posts/2019-05-14 introducing-reactphp-sqlite.md
+++ b/www/_posts/2019-05-14 introducing-reactphp-sqlite.md
@@ -1,6 +1,5 @@
 ---
 title: Introducing async SQLite database for ReactPHP
-legacy_id: https://www.lueck.tv/2019/introducing-reactphp-sqlite
 tags:
   - introducing-reactphp
   - reactphp

--- a/www/_posts/2019-07-04 introducing-reactphp-cache.md
+++ b/www/_posts/2019-07-04 introducing-reactphp-cache.md
@@ -1,6 +1,5 @@
 ---
 title: Introducing async cache for ReactPHP
-legacy_id: https://www.lueck.tv/2019/introducing-reactphp-cache
 tags:
   - introducing-reactphp
   - reactphp

--- a/www/_posts/2019-07-11 announcing-reactphp-lts.md
+++ b/www/_posts/2019-07-11 announcing-reactphp-lts.md
@@ -1,7 +1,6 @@
 ---
 title: Announcing full stable ReactPHP LTS release
 social_image: https://user-images.githubusercontent.com/776829/61060544-39dd7400-a3ea-11e9-8184-50a680564518.png
-legacy_id: https://www.lueck.tv/2019/announcing-reactphp-lts
 tags:
   - reactphp
   - release

--- a/www/blog.html.twig
+++ b/www/blog.html.twig
@@ -70,9 +70,10 @@ use:
 
         <h2 id="{{ year }}" class="tagged tagged-{{ tags|join(" tagged-") }}"><a href="#{{ year }}"></a>{{ year }} <small>({{ posts }} {{ posts == 1 ? "post" : "posts" }})</small></h2>
 {%     endif %}
+{%     set link = post.external_url | default(post.url | replace({'.html':''}) | trim("/", "left")) %}
 
         <article class="tagged{% for tag in post.tags %} tagged-{{ tag }}{% endfor %}">
-            <h4><a href="{{ post.external_url | default("." ~ (post.url | replace({'.html':''}))) }}">{{ post.title }}</a></h4>
+            <h4><a href="{{ link }}">{{ post.title }}</a></h4>
             <ul>
                 <li><time>{{ post.date | date("Y-m-d") }}</time></li>
 {%     for tag in post.tags %}
@@ -80,7 +81,7 @@ use:
 {%     endfor %}
             </ul>
             <p>{{ post.blocks.content|raw|striptags|replace({"\n":' ', "\r":' '})|trim|split(' ')|slice(0,50)|join(' ')|raw }}…</p>
-            <a href="{{ post.external_url | default("." ~ (post.url | replace({'.html':''}))) }}"><em>Read more</em></a>
+            <a href="{{ link }}"><em>Read more</em></a>
         </article>
 {% endfor %}
     </div>

--- a/www/index.html.twig
+++ b/www/index.html.twig
@@ -76,8 +76,9 @@ use:
                 <a href="https://twitter.com/another_clue">Twitter</a>.
             </p>
 {% for post in data.posts[:3] %}
+{%     set link = post.external_url | default(post.url | replace({'.html':''}) | trim("/", "left")) %}
             <article>
-                <h4><a href="{{ post.external_url | default("." ~ (post.url | replace({'.html':''}))) }}">{{ post.title }}</a></h4>
+                <h4><a href="{{ link }}">{{ post.title }}</a></h4>
                 <ul>
                     <li><time>{{ post.date | date("Y-m-d") }}</time></li>
 {%     for tag in post.tags %}
@@ -85,7 +86,7 @@ use:
 {%     endfor %}
                 </ul>
                 <p>{{ post.blocks.content|raw|striptags|replace({"\n":' ', "\r":' '})|trim|split(' ')|slice(0,50)|join(' ')|raw }}…</p>
-                <a href="{{ post.external_url | default("." ~ (post.url | replace({'.html':''}))) }}"><em>Read more</em></a>
+                <a href="{{ link }}"><em>Read more</em></a>
             </article>
 {% endfor %}
             <p>

--- a/www/posts.atom.twig
+++ b/www/posts.atom.twig
@@ -11,10 +11,11 @@ permalink: posts.atom
     <link href="https://clue.engineering/blog" rel="alternate" type="text/html" />
     <id>https://clue.engineering/</id>
 {% for post in data.posts[:10] %}
+{%     set link = post.external_url | default("https://clue.engineering" ~ post.url | replace({'.html':''})) %}
     <entry>
         <title>{{ post.title }}</title>
-        <link href="{{ post.external_url | default("https://clue.engineering" ~ (post.url | replace({'.html':''}))) }}" />
-        <id>{{ post.external_url | default(post.legacy_id) | default("https://clue.engineering" ~ post.url | replace({'.html':''})) }}</id>
+        <link href="{{ link }}" />
+        <id>{{ link }}</id>
         <updated>{{ post.date | date("Y-m-d\\T00:00:00\\Z") }}</updated>
         <summary>{{ post.blocks.content|raw|striptags|replace({"\n":' ', "\r":' '})|trim|split(' ')|slice(0,50)|join(' ')|raw }}…</summary>
 {%     for tag in post.tags %}


### PR DESCRIPTION
This changeset unifies internal link building for blog posts and removes unneeded legacy IDs. It should not have any visible impact otherwise.