### PR TITLE
Fix workflow rendering HTML diff by using specific PHP version

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -11,7 +11,10 @@ jobs:
     steps:
       # check out base ref and build site into old/
       - uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
+          php-version: 8.0
           ref: ${{ github.event.pull_request.base.sha }}
       - run: composer install
       - run: vendor/bin/sculpin generate --output-dir=old


### PR DESCRIPTION
This uses the latest supported PHP version to successfully create the HTML diff.
Builds on top of #68.