### PR TITLE
Remove Userlike chat widget

### DIFF
--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -105,7 +105,5 @@
         </div>
       </div>
     </footer>
-
-    <script async type="text/javascript" src="https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com/eb0f44ef8dbe480ab49d3a956f88be6034cf2d42e0114c31a532dc47ad6a9da7.js"></script>
 </body>
 </html>

--- a/www/privacy.html
+++ b/www/privacy.html
@@ -174,54 +174,30 @@ layout: default
 </li>
 </ul>
 
-<h4>7. Data protection provisions about the application and use of Userlike</h4>
-<p>This website uses <a href="http://www.userlike.com/">Userlike</a>, live chat software produced by the company Userlike UG (haftungsbeschränkt), Probsteigasse 44-46, 50670 Cologne, Germany. You can use Userlike to chat with our employees in real-time. At the start of the chat, the following personal data is collected: </p>
-
-<ul style="list-style: outside;">
-<li>Date and time of the chat, </li>
-<li>Browser type/version, </li>
-<li>IP address, </li>
-<li>Operating system used, </li>
-<li>URL of the previously visited website, </li>
-<li>Amount of data sent. And if provided by you: first name, surname, and e-mail address.</li>
-</ul>
-
-<p>Depending on the course of the conversation with our employees, further personal data may be provided by you in the chat. The nature of this information depends heavily on your request or the problem you are describing.</p>
-
-<p>All our employees have been trained in data protection and in the handling of customer data. All our employees are obliged to maintain confidentiality and have accordingly signed an addendum to their employment contracts which obliges them to maintain confidentiality and observe data protection.</p>
-
-<p>By accessing our website, the chat widget is loaded as a JavaScript file from AWS Cloudfront. The chat widget technically represents the source code executed on your computer that enables the chat.</p>
-
-<p>In addition, clue·engineering (Christian Lück) stores the history of live chats. The purpose of this is to save our customers from having to go through a long history of requests, and for us to constantly monitor the quality of our live chat service. Processing is permitted pursuant to Art. 6 Para. 1 Book f, GDPR. If you do not wish your live chat history to be stored, please do not hesitate to contact us using the contact details listed in this document. Stored live chats and any other of your data will then be deleted by us immediately.</p>
-
-<p>The storage of chat data also serves the purpose of ensuring the security of our information technology systems. This is also our legitimate interest, which is why processing is permitted under Art. 6 Para. 1 Book f, GDPR. The legal basis for the processing of the data provided in the chat is also Art. 6 Para. 1 Books b and f, GDPR.</p>
-
-<p>Further information can be found in the <a href="http://www.userlike.com/terms#privacy-policy">Data processing terms of Userlike</a> UG (haftungsbeschränkt).</p>
-
-<h4>8. Data protection provisions about the application and use of Plausible Analytics</h4>
+<h4>7. Data protection provisions about the application and use of Plausible Analytics</h4>
 <p>We use the open source Plausible Analytics to track overall trends in the usage of our website. Plausible Analytics collects only aggregated information, which does not allow us to identify any visitor to our website. For more information, please visit the <a href="https://plausible.io/data-policy">Plausible Analytics Data Policy</a>.
 
-<h4>9. Appointments via Calendly</h4>
+<h4>8. Appointments via Calendly</h4>
 <p>We use the tool Calendly to arrange appointments in a simple, fast and uncomplicated way. We use Calendly to improve our service for new clients and schedule appointments. This represents a legitimate interest within the meaning of Art. 6 Para. 1 lit. f DSGVO.</p>
 
 <p>When using the tool, you will be asked for personal data such as name and your e-mail address. You also have the opportunity to present your request and provide us with further information. If you use the tool, your data from the inquiry form, including the information you provide there, will be stored and, of course, transmitted on the Internet. The processing of the data entered is based exclusively on your consent (Art. 6 para. 1 lit. a DSGVO).</p>
 
 <p>This privacy policy and the provider's privacy policy apply to the handling of data collected through the use of Calendly. Further information can be found in the <a href="https://calendly.com/pages/privacy">privacy policy of Calendly</a>.</p>
 
-<h4>10. Legal basis for the processing </h4>
+<h4>9. Legal basis for the processing </h4>
 
 <p>Art. 6(1) lit. a GDPR serves as the legal basis for processing operations for which we obtain consent for a specific processing purpose. If the processing of personal data is necessary for the performance of a contract to which the data subject is party, as is the case, for example, when processing operations are necessary for the supply of goods or to provide any other service, the processing is based on Article 6(1) lit. b GDPR. The same applies to such processing operations which are necessary for carrying out pre-contractual measures, for example in the case of inquiries concerning our products or services. Is our company subject to a legal obligation by which processing of personal data is required, such as for the fulfillment of tax obligations, the processing is based on Art. 6(1) lit. c GDPR.
 In rare cases, the processing of personal data may be necessary to protect the vital interests of the data subject or of another natural person. This would be the case, for example, if a visitor were injured in our company and his name, age, health insurance data or other vital information would have to be passed on to a doctor, hospital or other third party. Then the processing would be based on Art. 6(1) lit. d GDPR.
 Finally, processing operations could be based on Article 6(1) lit. f GDPR. This legal basis is used for processing operations which are not covered by any of the abovementioned legal grounds, if processing is necessary for the purposes of the legitimate interests pursued by our company or by a third party, except where such interests are overridden by the interests or fundamental rights and freedoms of the data subject which require protection of personal data. Such processing operations are particularly permissible because they have been specifically mentioned by the European legislator. He considered that a legitimate interest could be assumed if the data subject is a client of the controller (Recital 47 Sentence 2 GDPR).
 </p>
 
-<h4>11. The legitimate interests pursued by the controller or by a third party</h4>
+<h4>10. The legitimate interests pursued by the controller or by a third party</h4>
 <p>Where the processing of personal data is based on Article 6(1) lit. f GDPR our legitimate interest is to carry out our business in favor of the well-being of all our employees and the shareholders.</p>
 
-<h4>12. Period for which the personal data will be stored</h4>
+<h4>11. Period for which the personal data will be stored</h4>
 <p>The criteria used to determine the period of storage of personal data is the respective statutory retention period. After expiration of that period, the corresponding data is routinely deleted, as long as it is no longer necessary for the fulfillment of the contract or the initiation of a contract.</p>
 
-<h4>13. Provision of personal data as statutory or contractual requirement; Requirement necessary to enter into a contract; Obligation of the data subject to provide the personal data; possible consequences of failure to provide such data </h4>
+<h4>12. Provision of personal data as statutory or contractual requirement; Requirement necessary to enter into a contract; Obligation of the data subject to provide the personal data; possible consequences of failure to provide such data </h4>
 <p>We clarify that the provision of personal data is partly required by law (e.g. tax regulations) or can also result from contractual provisions (e.g. information on the contractual partner).
 
 Sometimes it may be necessary to conclude a contract that the data subject provides us with personal data, which must subsequently be processed by us. The data subject is, for example, obliged to provide us with personal data when our company signs a contract with him or her. The non-provision of the personal data would have the consequence that the contract with the data subject could not be concluded.
@@ -229,7 +205,7 @@ Sometimes it may be necessary to conclude a contract that the data subject provi
 Before personal data is provided by the data subject, the data subject must contact any employee. The employee clarifies to the data subject whether the provision of the personal data is required by law or contract or is necessary for the conclusion of the contract, whether there is an obligation to provide the personal data and the consequences of non-provision of the personal data.
 </p>
 
-<h4>14. Existence of automated decision-making</h4>
+<h4>13. Existence of automated decision-making</h4>
 <p>As a responsible company, we do not use automatic decision-making or profiling.</p>
 
 <p><small>This Privacy Policy has been generated by the Privacy Policy Generator of the <a href="https://dg-datenschutz.de/services/external-data-protection-officer/?lang=en">External Data Protection Officers</a> that was developed in cooperation with the <a href="https://www.wbs-law.de/eng/practice-areas/media-law/">Media Law Lawyers</a> from WBS-LAW.


### PR DESCRIPTION
Removes the Userlike chat widget from the website and updates the privacy policy accordingly.

Builds on top of #65.